### PR TITLE
Update manifest.json for Firefox support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -393,5 +393,12 @@
       "type": "module",
       "run_at": "document_start"
     }
-  ]
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "Google_AI_Overviews_Blocker@zachbarnes.dev",
+      "strict_min_version": "58.0"
+    },
+    "gecko_android": {}
+  }
 }


### PR DESCRIPTION
Adding an ID and min version makes it uploadable at addons.mozilla.org

Adding the gecko_android key means it will work on mobile Firefox, too, though you still have to check the option when uploading it to AMO. 