### PR TITLE
Hide "AI Overview" in "People also ask" section

### DIFF
--- a/content.js
+++ b/content.js
@@ -16,6 +16,15 @@ const observer = new MutationObserver(() => {
   if (mainElement) {
     mainElement.style.marginTop = "24px";
   }
+
+  // Remove entries in "People also ask" section if it contains "AI overview"
+  const peopleAlsoAskAiOverviews = [
+    ...document.querySelectorAll("div.related-question-pair"),
+  ].filter((el) => patterns.some((pattern) => pattern.test(el.innerHTML)));
+
+  peopleAlsoAskAiOverviews.forEach((el) => {
+    el.parentElement.parentElement.style.display = "none";
+  });
 });
 
 observer.observe(document, {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide Google AI Overviews",
-  "version": "1.4",
+  "version": "1.5",
   "description": "Hide annoying Google AI Overviews.",
   "permissions": ["scripting"],
   "icons": {


### PR DESCRIPTION
Addressing #13 to also hide "AI Overview" in "People also ask" section.

| Extension disabled | Extension enabled |
|:-:|:-:|
|![Screenshot 2025-05-17 at 14 45 08](https://github.com/user-attachments/assets/82503ffa-0f14-46ba-9a89-995360d255d7) Main "AI Overview" is visible and in the "People also ask" section as usual |![Screenshot 2025-05-17 at 14 45 27](https://github.com/user-attachments/assets/6a0e1e47-a08d-4bb4-b379-e117e9a3435c) The "AI Overview" entries are now excluded from "People also ask" section |

## How the selector works

Each "AI Overview" list entries are contained in a `div[jsname=somerandomchar]` element, the nearest selectable child element is two-level below with the `related-question-pair` class name.

![image](https://github.com/user-attachments/assets/261a790d-9f30-425d-b995-7aa8f7662536)

Then the use the regex to match against `innerHTML` since the "AI Overview" text is deep down under the `div.related-question-pair` element.

![image](https://github.com/user-attachments/assets/5b740baf-fc94-4da4-bec2-67830cdb4516)

After that iterate for each "AI Overview" entries and apply `display: none` as usual.