### PR TITLE
Refactor and check all search results for ai overview

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,4 +1,5 @@
-const patterns = [
+// AI Overview text patterns for different languages
+const AI_OVERVIEW_PATTERNS = [
   /übersicht mit ki/i, // de
   /ai overview/i, // en
   /prezentare generală generată de ai/i, // ro
@@ -10,47 +11,90 @@ const patterns = [
   /Přehled od AI/i, // cz
 ];
 
-const observer = new MutationObserver(() => {
-  // each time there's a mutation in the document see if there's an ai overview to hide
-  const mainBody = document.querySelector("div#rcnt");
-  const aiText = [...mainBody?.querySelectorAll("h1, h2")].find((e) =>
-    patterns.some((pattern) => pattern.test(e.innerText))
+// CSS selectors for AI overview containers
+const AI_OVERVIEW_SELECTORS = {
+  SEARCH_RESULT_SELECTOR: "div#rso > div", 
+  ABOVE_SEARCH_RESULTS_SELECTOR: "div#rcnt > div", 
+};
+
+// Main DOM selectors
+const DOM_SELECTORS = {
+  MAIN_BODY: "div#rcnt",
+  HEADER_TABS: "div#hdtb-sc > div",
+  MAIN_ELEMENT: '[role="main"]',
+  PEOPLE_ALSO_ASK: "div.related-question-pair",
+  TABS_LIST: '[role="list"]',
+};
+
+// CSS values
+const CSS_VALUES = {
+  HIDDEN: "none",
+  HEADER_PADDING: "12px",
+  MAIN_MARGIN: "24px",
+};
+
+// Tab patterns
+const TAB_PATTERNS = {
+  AI_MODE: /^AI Mode$/i,
+};
+
+const getAiOverview = (mainBody) => {
+  // Find all headings that match AI overview patterns
+  const aiTexts = [...mainBody?.querySelectorAll("h1, h2")].filter((e) =>
+    AI_OVERVIEW_PATTERNS.some((pattern) => pattern.test(e.innerText))
   );
 
-  var aiOverview = aiText?.closest("div#rso > div"); // AI overview as a search result
-  if (!aiOverview) aiOverview = aiText?.closest("div#rcnt > div"); // AI overview above search results
+  // For each matching heading, check both possible div containers
+  for (const aiText of aiTexts) {
+    // Check AI overview as a search result
+    const aiOverviewAsResult = aiText?.closest(AI_OVERVIEW_SELECTORS.SEARCH_RESULT_SELECTOR);
+    if (aiOverviewAsResult) return aiOverviewAsResult;
+    
+    // Check AI overview above search results
+    const aiOverviewAbove = aiText?.closest(AI_OVERVIEW_SELECTORS.ABOVE_SEARCH_RESULTS_SELECTOR);
+    if (aiOverviewAbove) return aiOverviewAbove;
+  }
+
+  return null;
+};
+
+const observer = new MutationObserver(() => {
+  // each time there's a mutation in the document see if there's an ai overview to hide
+  const mainBody = document.querySelector(DOM_SELECTORS.MAIN_BODY);
+  
+  const aiOverview = getAiOverview(mainBody);
 
   // Hide AI overview
-  if (aiOverview) aiOverview.style.display = "none";
+  if (aiOverview) aiOverview.style.display = CSS_VALUES.HIDDEN;
 
   // Restore padding after header tabs
-  const headerTabs = document.querySelector("div#hdtb-sc > div");
-  if (headerTabs) headerTabs.style.paddingBottom = "12px";
+  const headerTabs = document.querySelector(DOM_SELECTORS.HEADER_TABS);
+  if (headerTabs) headerTabs.style.paddingBottom = CSS_VALUES.HEADER_PADDING;
 
   // For debugging
   // console.log([...mainBody?.querySelectorAll('h1, h2')].map(e => { return { text: e.innerText, obj: e }}));
-  const mainElement = document.querySelector('[role="main"]');
+  const mainElement = document.querySelector(DOM_SELECTORS.MAIN_ELEMENT);
   if (mainElement) {
-    mainElement.style.marginTop = "24px";
+    mainElement.style.marginTop = CSS_VALUES.MAIN_MARGIN;
   }
 
   // Remove entries in "People also ask" section if it contains "AI overview"
   const peopleAlsoAskAiOverviews = [
-    ...document.querySelectorAll("div.related-question-pair"),
-  ].filter((el) => patterns.some((pattern) => pattern.test(el.innerHTML)));
+    ...document.querySelectorAll(DOM_SELECTORS.PEOPLE_ALSO_ASK),
+  ].filter((el) => AI_OVERVIEW_PATTERNS.some((pattern) => pattern.test(el.innerHTML)));
 
   peopleAlsoAskAiOverviews.forEach((el) => {
-    el.parentElement.parentElement.style.display = "none";
+    el.parentElement.parentElement.style.display = CSS_VALUES.HIDDEN;
   });
 
   // Hide AI Mode tab
-  const tabsList = document.querySelector('[role="list"]').children;
+  const tabsList = document.querySelector(DOM_SELECTORS.TABS_LIST).children;
   const aiModeTab = tabsList[0];
 
   const text = aiModeTab.innerText.trim();
 
-  if (/^AI Mode$/i.test(text)) {
-    aiModeTab.style.display = "none";
+  if (TAB_PATTERNS.AI_MODE.test(text)) {
+    aiModeTab.style.display = CSS_VALUES.HIDDEN;
   }
 });
 


### PR DESCRIPTION
for #40

Standardized/cleaned up some code with consts and enums. 
Issue 40 is in regards to AI overviews sneaking past if they are not the first item in the search results. 
This solution attempts to fix it by iterating over all search results. While this is an downgrade from an O(1) solution to a O(N), it is necessary to get all such cases where AI overview can pop up. 

Also, considering that search results are capped to a certain amount before the next page - it's easy to assume N <= 10 if the user does not explicitly set their search results per page to be larger than the default. 

Before:
<img width="1167" height="833" alt="Screenshot 2026-02-11 at 1 17 43 PM" src="https://github.com/user-attachments/assets/acbc9e17-d697-49cb-8a4a-8ceff07a66d7" />
After:
<img width="1177" height="831" alt="Screenshot 2026-02-11 at 1 18 02 PM" src="https://github.com/user-attachments/assets/68256561-cfc1-4d8d-b760-b93be86309c2" />
